### PR TITLE
Add style analysis plot and adjust training

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ The data collector now supports three driving styles:
 - **cautious** – keeps lower speeds and avoids risky moves
 - **normal** – a balanced heuristic
 
-After training, an animation of the training environment is saved as
-`training_animation.mp4`.
+After training, a plot comparing the three driving styles is saved as
+`style_analysis.png`. An animation of the evaluation episodes is also
+generated as `decision_transformer_highway.mp4`.
 
 Collected trajectories are stored in `highway_trajectories.pkl`. If this
 file already exists, the main script will load it instead of collecting


### PR DESCRIPTION
## Summary
- analyze trajectories for each driving style and save a `style_analysis.png`
- disable recording of training animation
- generate evaluation animation after training
- document new outputs in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 main.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684d2200fa3c83338cf82ac349d2aafb