### PR TITLE
Add trajectory caching helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ The data collector now supports three driving styles:
 - **cautious** – keeps lower speeds and avoids risky moves
 - **normal** – a balanced heuristic
 
-After training, an animation of the training environment is saved as
-`training_animation.mp4`.
+After training, a plot comparing the three driving styles is saved as
+`style_analysis.png`. An animation of the evaluation episodes is also
+generated as `decision_transformer_highway.mp4`.
 
 Collected trajectories are stored in `highway_trajectories.pkl`. If this
 file already exists, the main script will load it instead of collecting

--- a/decision_transformer/data.py
+++ b/decision_transformer/data.py
@@ -278,8 +278,31 @@ class HighwayDataCollector:
 
         if speed > 20:
             return 2  # SLOWER
+
         for i in range(1, len(obs)):
             if obs[i][0] and obs[i][1] > x and abs(obs[i][2]-y) < 2 and obs[i][1]-x < 15:
                 return 2
         return 0
+
+
+def load_or_collect_trajectories(
+    file_path: str = "highway_trajectories.pkl",
+    num_trajs_per_style: int = 20,
+) -> list:
+    """Load cached trajectories if available, otherwise collect and save them."""
+    if os.path.exists(file_path):
+        print(f"Loading trajectories from {file_path}...")
+        with open(file_path, "rb") as f:
+            return pickle.load(f)
+
+    print("Collecting trajectories...")
+    collector = HighwayDataCollector()
+    aggressive = collector.collect_aggressive_trajectories(num_trajs_per_style)
+    cautious = collector.collect_cautious_trajectories(num_trajs_per_style)
+    normal = collector.collect_expert_trajectories(num_trajs_per_style)
+    trajectories = aggressive + cautious + normal
+
+    with open(file_path, "wb") as f:
+        pickle.dump(trajectories, f)
+    return trajectories
 

--- a/main.py
+++ b/main.py
@@ -9,41 +9,62 @@ from collections import defaultdict
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 from matplotlib.patches import Rectangle
-import pickle
 from typing import List, Tuple, Dict
 import math
 import cv2
-import os
 from PIL import Image
 import seaborn as sns
 
 from decision_transformer.model import DecisionTransformer
-from decision_transformer.data import HighwayDataset, HighwayDataCollector
+from decision_transformer.data import (
+    HighwayDataset,
+    load_or_collect_trajectories,
+)
 from decision_transformer.trainer import DecisionTransformerTrainer
 from decision_transformer.evaluator import HighwayEvaluator
+
+
+def analyze_trajectories_by_style(trajectories, output_file="style_analysis.png"):
+    """Create plots comparing returns and action usage for each driving style."""
+    styles = defaultdict(list)
+    for traj in trajectories:
+        styles[traj.get("style", "normal")].append(traj)
+
+    num_styles = len(styles)
+    fig, axes = plt.subplots(num_styles, 2, figsize=(10, 4 * num_styles))
+
+    if num_styles == 1:
+        axes = np.array([axes])
+
+    action_names = ["IDLE", "FASTER", "SLOWER", "LANE_LEFT", "LANE_RIGHT"]
+
+    for idx, (style, trajs) in enumerate(sorted(styles.items())):
+        returns = [sum(t["rewards"]) for t in trajs]
+        axes[idx, 0].hist(returns, bins=10, color="skyblue")
+        axes[idx, 0].set_title(f"{style.capitalize()} Returns")
+        axes[idx, 0].set_xlabel("Return")
+        axes[idx, 0].set_ylabel("Frequency")
+
+        action_counts = np.zeros(len(action_names))
+        for t in trajs:
+            for a in t["actions"]:
+                action_counts[a] += 1
+        axes[idx, 1].bar(action_names, action_counts, color="salmon")
+        axes[idx, 1].set_title(f"{style.capitalize()} Action Distribution")
+        axes[idx, 1].set_ylabel("Count")
+
+    plt.tight_layout()
+    plt.savefig(output_file)
+    plt.close(fig)
+    print(f"Style analysis saved to {output_file}")
 
 def main():
     """Main training and evaluation pipeline"""
     
-    # 1. Load existing trajectories or collect new ones
-    data_file = 'highway_trajectories.pkl'
-
-    if os.path.exists(data_file):
-        print(f"Loading trajectories from {data_file}...")
-        with open(data_file, 'rb') as f:
-            all_trajectories = pickle.load(f)
-    else:
-        print("Collecting trajectories...")
-        collector = HighwayDataCollector()
-
-        # Collect trajectories from three driving styles
-        aggressive_trajs = collector.collect_aggressive_trajectories(20)
-        cautious_trajs = collector.collect_cautious_trajectories(20)
-        normal_trajs = collector.collect_expert_trajectories(20)
-        all_trajectories = aggressive_trajs + cautious_trajs + normal_trajs
-
-        with open(data_file, 'wb') as f:
-            pickle.dump(all_trajectories, f)
+    # 1. Load cached trajectories or collect new ones
+    all_trajectories = load_or_collect_trajectories(
+        file_path="highway_trajectories.pkl", num_trajs_per_style=20
+    )
     
     # 2. Create dataset
     print("Creating dataset...")
@@ -69,9 +90,11 @@ def main():
         dataset,
         num_epochs=100,
         batch_size=32,
-        record_animation=True,
+        record_animation=False,
         animation_file="training_animation.mp4",
     )
+
+    analyze_trajectories_by_style(all_trajectories)
     
     # Save model
     torch.save(model.state_dict(), 'decision_transformer_highway.pth')
@@ -80,6 +103,7 @@ def main():
     print("Evaluating model...")
     evaluator = HighwayEvaluator(model)
     results = evaluator.evaluate(num_episodes=50, target_return=25)
+    evaluator.evaluate_with_animation(num_episodes=5, target_return=25, save_animation=True)
     
     print("\nEvaluation Results:")
     print(f"Mean Return: {results['mean_return']:.2f} ± {results['std_return']:.2f}")


### PR DESCRIPTION
## Summary
- add `load_or_collect_trajectories` helper in `data.py`
- refactor `main.py` to call new helper
- keep style analysis plot and skip training animation

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 main.py` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_684d2200fa3c83338cf82ac349d2aafb